### PR TITLE
Create and return a new error to avoid altering an error argument.

### DIFF
--- a/lib/createError.js
+++ b/lib/createError.js
@@ -47,24 +47,49 @@
         var optionsWithoutData = extend({}, options);
         delete optionsWithoutData.data;
 
-        function Constructor(messageOrOptionsOrError) {
+        function Constructor(messageOrOptionsOrError, preserveError) {
             var err;
+            var shouldCapture = false;
+
             if (messageOrOptionsOrError instanceof Error) {
                 // Existing instance
                 err = messageOrOptionsOrError;
+
+                // if called to extend an existing error we replace it
+                if (!preserveError) {
+                    err = messageOrOptionsOrError;
+
+                    // ensure we add both message and stack from original error
+                    messageOrOptionsOrError = {
+                        message: err.message,
+                        stack: err.stack
+                    };
+
+                    // attach all other properties from the original error
+                    extend(messageOrOptionsOrError, err);
+
+                    // explicitly clear error to force creation of a new one
+                    err = undefined;
+                }
             } else {
+                shouldCapture = true;
+
                 if (typeof messageOrOptionsOrError === 'string') {
                     messageOrOptionsOrError = {message: messageOrOptionsOrError};
                 }
-                // https://github.com/joyent/node/issues/3212#issuecomment-5493890
+            }
+
+            if (!err) {
                 err = new Error();
+                // https://github.com/joyent/node/issues/3212#issuecomment-5493890
                 err.__proto__ = Constructor.prototype;
-                if (Error.captureStackTrace) {
+                if (shouldCapture && Error.captureStackTrace) {
                     Error.captureStackTrace(err, Constructor);
                 }
             }
+
             if (SuperConstructor) {
-                SuperConstructor.call(err, err);
+                SuperConstructor.call(err, err, true);
             }
 
             extend(err, optionsWithoutData);

--- a/test/createError.js
+++ b/test/createError.js
@@ -101,4 +101,22 @@ describe('createError', function () {
 
         expect(err2.data.foo, 'to be undefined');
     });
+
+    it('should not alter an existing error', function () {
+        var classData = {hey: 'there'};
+        var LocalError = createError({name: 'LocalError', data: classData}),
+            SpecificLocalError = createError({name: 'SpecificLocalError'}, LocalError),
+            err = new Error('standard error');
+
+        // create a new local error passing in the original error
+        var localError = new SpecificLocalError(err);
+
+        // assert we added no keys to the orignal
+        expect(err, 'to only have keys', ['message']);
+
+        // assert the error was correctly extended
+        expect(localError, 'to have message', 'standard error');
+        expect(localError.name, 'to equal', 'SpecificLocalError');
+        expect(localError.data, 'to equal', classData);
+    });
 });


### PR DESCRIPTION
This pull request alters createerror to ensure that an an existing error passed into a constructor is not altered. Previously, an existing error passed in had properties attached to it and it's constructor reset.